### PR TITLE
Automatic quiz creation in a quiet channel

### DIFF
--- a/app.js
+++ b/app.js
@@ -524,11 +524,17 @@ app.view('quiz_submit', async ({ ack, body, view, client }) => {
         const { creatorId, type: quizTypeLabel, question } = session;
 
         // Luăm numele creatorului
-        const creatorInfo = await client.users.info({ user: creatorId });
-        const creatorName =
+        let creatorName;
+        try {
+          const creatorInfo = await client.users.info({ user: creatorId });
+
+          const creatorName =
             creatorInfo.user.profile.display_name ||
             creatorInfo.user.profile.real_name ||
             creatorInfo.user.name;
+        } catch (error) {
+          creatorName = 'Unknown Creator';
+        }
 
         // Construim textul
         let text;

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ dotenv.config({ quiet: true });
 
 import pkg from '@slack/bolt';
 import axios from 'axios';
+import initSlackAutoQuiz from "./slackAutoQuiz.js";
 import { createClient } from '@supabase/supabase-js';
 import { handleQuizTimeout } from './handleQuizTimeout.js';
 
@@ -298,7 +299,7 @@ app.view('brainbuzz_modal', async ({ ack, body, view, client }) => {
                     }
                 ]
             });
-
+            
             const messageTs = postResult.ts;
 
             quizSessionMap.set(quiz.quiz_id, {
@@ -362,7 +363,7 @@ app.view('brainbuzz_modal', async ({ ack, body, view, client }) => {
                     ]
                 });
             }, 5000);
-
+            console.log('Feedback message sent to user', body.user.id);
         } catch (error) {
             console.error('❌ Error posting Start Quiz message:', error);
         }
@@ -486,7 +487,7 @@ app.action('start_quiz', async ({ ack, body, client }) => {
 app.view('quiz_submit', async ({ ack, body, view, client }) => {
     // Acknowledge the submission
     await ack();
-
+    console.log('User ID primit din body:', body.user.id);
     // 2️⃣ Extrage quiz_id din private_metadata și sesiunea asociată
     const quizId = view.private_metadata;
     const session = quizSessionMap.get(quizId);
@@ -588,4 +589,6 @@ app.view('quiz_submit', async ({ ack, body, view, client }) => {
 (async () => {
     await app.start(process.env.PORT || 3000);
     app.logger.info('BrainBuzz is up and running!');
+
+    initSlackAutoQuiz(app, quizSessionMap);
 })();

--- a/quizFlow.js
+++ b/quizFlow.js
@@ -1,0 +1,173 @@
+    import axios from "axios";
+
+    
+export async function startQuizFlow({
+  app,
+  client,
+  quizSessionMap,
+  user,
+  channel,
+  quizType,
+  durationSec,
+  originChannel, // optional, poți omite dacă nu ai nevoie
+}) {
+  try {
+    // 1️⃣ Mapează tipul la ce cere backendul
+    const typeMap = {
+      historical: "historical",
+      icebreaker: "icebreaker",
+      movie_quote: "movie_quote",
+      history: "historical", // suportă sinonime
+      funny: "icebreaker",
+      movie: "movie_quote",
+    };
+
+    const backendType = typeMap[quizType] || quizType;
+
+    // 2️⃣ Cere quiz de la backend
+    const res = await axios.get(
+      `http://localhost:3000/quiz?type=${backendType}&duration=${durationSec}`
+    );
+    const quiz = res.data;
+    if (!quiz) throw new Error("No quiz data received");
+
+    // 3️⃣ Calculează endTime și creează ID pentru sesiune
+    const now = Date.now();
+    const endTime = now + durationSec * 1000;
+    const quizId = quiz.quiz_id || `quiz_${Date.now()}`;
+
+    // 4️⃣ Stochează sesiunea în map
+    quizSessionMap.set(quizId, {
+      quiz,
+      endTime,
+      usersAnswered: [],
+      creatorId: user.id,
+      type: quizType,
+      question: quiz.quizText,
+    });
+
+    // 5️⃣ Funcție pentru formatat timpul în mm:ss
+    function formatTime(seconds) {
+      const m = Math.floor(seconds / 60);
+      const s = seconds % 60;
+      return `${m}:${s.toString().padStart(2, "0")}`;
+    }
+
+    // 6️⃣ Postează mesajul în canal cu buton Start Quiz
+    const typeNameMap = {
+      historical: "Historical",
+      icebreaker: "Funny/Icebreaker",
+      movie_quote: "Popular quote",
+    };
+
+    const postResult = await client.chat.postMessage({
+      channel,
+      text: "BrainBuzz Quiz!",
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `@${user.name} has started a new ${typeNameMap[quizType]?.toLowerCase() || quizType} quiz!\nClick the *Start Quiz* button below to give it a try.\n*Time remaining:* ${formatTime(durationSec)}`,
+          },
+        },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Start Quiz" },
+              action_id: "start_quiz",
+              value: quizId,
+            },
+          ],
+        },
+        ...(quiz.imageUrl
+          ? [
+              {
+                type: "image",
+                image_url: quiz.imageUrl,
+                alt_text: "Quiz Image",
+              },
+            ]
+          : []),
+      ],
+    });
+
+    const messageTs = postResult.ts;
+
+    // 7️⃣ Actualizează sesiunea cu info despre canal și thread_ts
+    quizSessionMap.set(quizId, {
+      ...quizSessionMap.get(quizId),
+      channel: postResult.channel,
+      threadTs: messageTs,
+    });
+
+    // 8️⃣ Setează interval care actualizează mesajul la fiecare 5 secunde
+    let remaining = durationSec;
+    const intervalId = setInterval(async () => {
+      remaining = Math.max(0, Math.floor((endTime - Date.now()) / 1000));
+
+      if (remaining <= 0) {
+        clearInterval(intervalId);
+        await client.chat.update({
+          channel,
+          ts: messageTs,
+          text: "Quiz closed!",
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: `⏰ The quiz has ended!`,
+              },
+            },
+          ],
+        });
+        return;
+      }
+
+      await client.chat.update({
+        channel,
+        ts: messageTs,
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `@${user.name} has started a new ${typeNameMap[quizType]?.toLowerCase() || quizType} quiz!\nClick the *Start Quiz* button below to give it a try.\n*Time remaining:* ${formatTime(remaining)}`,
+            },
+          },
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                text: { type: "plain_text", text: "Start Quiz" },
+                action_id: "start_quiz",
+                value: quizId,
+              },
+            ],
+          },
+          ...(quiz.imageUrl
+            ? [
+                {
+                  type: "image",
+                  image_url: quiz.imageUrl,
+                  alt_text: "Quiz Image",
+                },
+              ]
+            : []),
+        ],
+      });
+    }, 5000);
+
+    // 9️⃣ Poți să apelezi aici funcția de timeout dacă o ai, ex:
+    // handleQuizTimeout(quizId, endTime, app, quizSessionMap);
+
+    return quizId; // întoarce id-ul quiz-ului
+  } catch (err) {
+    console.error("❌ Eroare în startQuizFlow:", err);
+    return null;
+  }
+}

--- a/quizFlow.js
+++ b/quizFlow.js
@@ -1,4 +1,5 @@
     import axios from "axios";
+    import { handleQuizTimeout } from './handleQuizTimeout.js';
 
     
 export async function startQuizFlow({
@@ -31,9 +32,17 @@ export async function startQuizFlow({
     const quiz = res.data;
     if (!quiz) throw new Error("No quiz data received");
 
+    // print correct answer
+    console.log('Quiz correct answer:', quiz.answer);
+
     // 3️⃣ Calculează endTime și creează ID pentru sesiune
     const now = Date.now();
+    // NOTE: hardcoded duration
     const endTime = now + durationSec * 1000;
+    // NOTE: quiz_id is received from backend
+    if (!quiz.quiz_id) {
+      console.warn("Quiz ID not provided, generating a new one.");
+    }
     const quizId = quiz.quiz_id || `quiz_${Date.now()}`;
 
     // 4️⃣ Stochează sesiunea în map
@@ -68,7 +77,7 @@ export async function startQuizFlow({
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `@${user.name} has started a new ${typeNameMap[quizType]?.toLowerCase() || quizType} quiz!\nClick the *Start Quiz* button below to give it a try.\n*Time remaining:* ${formatTime(durationSec)}`,
+            text: `It's too quiet in here! Anyone up for a ${typeNameMap[quizType]?.toLowerCase() || quizType} quiz!\nClick the *Start Quiz* button below to give it a try.\n*Time remaining:* ${formatTime(durationSec)}`,
           },
         },
         {
@@ -163,9 +172,11 @@ export async function startQuizFlow({
     }, 5000);
 
     // 9️⃣ Poți să apelezi aici funcția de timeout dacă o ai, ex:
-    // handleQuizTimeout(quizId, endTime, app, quizSessionMap);
+    handleQuizTimeout(quizId, endTime, app, quizSessionMap);
 
+    // NOTE: returning quizId is done
     return quizId; // întoarce id-ul quiz-ului
+U
   } catch (err) {
     console.error("❌ Eroare în startQuizFlow:", err);
     return null;

--- a/slackAutoQuiz.js
+++ b/slackAutoQuiz.js
@@ -11,8 +11,8 @@ export default function initSlackAutoQuiz(app, quizSessionMap) {
   }
 
   async function wasChannelActiveRecently(channelId, hours = 2) {
-    // corectat interval la 2 ore (2*3600*1000 ms)
-    const sinceTs = (Date.now() - 120 * 1000) / 1000;
+    // check every `hours` hours
+    const sinceTs = (Date.now() - hours * 3600 * 1000) / 1000;
     const history = await app.client.conversations.history({
       channel: channelId,
       oldest: sinceTs.toString(),
@@ -22,10 +22,11 @@ export default function initSlackAutoQuiz(app, quizSessionMap) {
   }
 
   async function autoPostQuiz() {
+    const hourFrequency = 2;
     try {
-      const active = await wasChannelActiveRecently(AUTO_CHANNEL_ID, 2);
+      const active = await wasChannelActiveRecently(AUTO_CHANNEL_ID, hourFrequency);
       if (active) {
-        console.log("⚠️ Canalul a fost activ în ultimele 2 ore. Nu postez quiz.");
+        console.log(`⚠️ Canalul a fost activ în ultimele ${hourFrequency} ore. Nu postez quiz.`);
         return;
       }
 

--- a/slackAutoQuiz.js
+++ b/slackAutoQuiz.js
@@ -1,0 +1,59 @@
+import axios from "axios";
+import { startQuizFlow } from "./quizFlow.js"; // ajustează calea corect
+
+export default function initSlackAutoQuiz(app, quizSessionMap) {
+  const AUTO_CHANNEL_ID = process.env.SLACK_CHANNEL_ID;
+
+  const quizTypes = ["historical", "icebreaker", "movie_quote"];
+
+  function getRandomType() {
+    return quizTypes[Math.floor(Math.random() * quizTypes.length)];
+  }
+
+  async function wasChannelActiveRecently(channelId, hours = 2) {
+    // corectat interval la 2 ore (2*3600*1000 ms)
+    const sinceTs = (Date.now() - 120 * 1000) / 1000;
+    const history = await app.client.conversations.history({
+      channel: channelId,
+      oldest: sinceTs.toString(),
+      limit: 1,
+    });
+    return history.messages && history.messages.length > 0;
+  }
+
+  async function autoPostQuiz() {
+    try {
+      const active = await wasChannelActiveRecently(AUTO_CHANNEL_ID, 2);
+      if (active) {
+        console.log("⚠️ Canalul a fost activ în ultimele 2 ore. Nu postez quiz.");
+        return;
+      }
+
+      const randomType = getRandomType();
+      const durationSec = 60;
+
+      // Folosește startQuizFlow, trimite parametrii necesari
+      const quizId = await startQuizFlow({
+        app,
+        client: app.client,
+        quizSessionMap,
+        user: { id: "auto-bot", name: "AutoBot" },
+        channel: AUTO_CHANNEL_ID,
+        quizType: randomType,
+        durationSec,
+      });
+
+      if (quizId) {
+        console.log("✅ Quiz automat postat cu succes, id:", quizId);
+      }
+    } catch (err) {
+      console.error("❌ Eroare la autoPostQuiz:", err);
+    }
+  }
+
+  // Interval la 10 minute (600000 ms)
+  setInterval(autoPostQuiz, 15 * 1000);
+
+  // Optional: poți să pornești prima oară imediat
+  autoPostQuiz();
+}


### PR DESCRIPTION
- The bot checks every 2 hours if a channel has been active (i.e. if users sent messages in it; reactions to messages or anything else is not taken into consideration as activity).
- If the channel has been inactive, the bot creates a quiz in it. Otherwise, it does not and checks for inactivity again in the next two hours (in which only the past 2 hours are taken into consideration).

**NOTE**: For development purposes, only a fixed channel (with its channel ID being set in `.env`  as `SLACK_CHANNEL_ID`) is checked. The implementation may have to change a bit to check all the channels a bot is a part of. Therefore, to test if this feature works, you have to provide a channel ID to check in.