### PR TITLE
Add support for new quiz type + Fix some issues

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,6 +94,13 @@ app.command('/brainbuzz', async ({ ack, body, client }) => {
                                         text: 'Movie/TV Quote Identification'
                                     },
                                     value: 'movie'
+                                },
+                                {
+                                    text: {
+                                        type: 'plain_text',
+                                        text: 'Computer Trivia (e.g. programming languages, tech history)'
+                                    },
+                                    value: 'computer_trivia'
                                 }
                             ]
                         },
@@ -236,7 +243,7 @@ app.view('brainbuzz_modal', async ({ ack, body, view, client }) => {
         // 3️⃣ Fetch quiz-ul de la backend
         let quiz;
         try {
-            const typeMap = { history: 'historical', funny: 'icebreaker', movie: 'movie_quote' };
+            const typeMap = { history: 'historical', funny: 'icebreaker', movie: 'movie_quote', computer_trivia: 'computer_trivia' };
             const backendType = typeMap[quizType] || quizType;
             const res = await axios.get(
                 `http://localhost:3000/quiz?type=${backendType}&duration=${durationSec}`
@@ -278,7 +285,8 @@ app.view('brainbuzz_modal', async ({ ack, body, view, client }) => {
         const typeNameMap = {
             history: 'Historical',
             funny: 'Funny/Icebreaker',
-            movie: 'Popular quote'
+            movie: 'Popular quote',
+            computer_trivia: 'Computer Trivia'
         };
 
         function formatTime(seconds) {

--- a/quizFlow.js
+++ b/quizFlow.js
@@ -21,6 +21,7 @@ export async function startQuizFlow({
       history: "historical", // suportă sinonime
       funny: "icebreaker",
       movie: "movie_quote",
+      computer_trivia: "computer_trivia",
     };
 
     const backendType = typeMap[quizType] || quizType;

--- a/slackAutoQuiz.js
+++ b/slackAutoQuiz.js
@@ -52,8 +52,8 @@ export default function initSlackAutoQuiz(app, quizSessionMap) {
     }
   }
 
-  // Interval la 10 minute (600000 ms)
-  setInterval(autoPostQuiz, 15 * 1000);
+  // Interval la 2 ore
+  setInterval(autoPostQuiz, 2 * 60 * 60 * 1000);
 
   // Optional: poți să pornești prima oară imediat
   autoPostQuiz();

--- a/slackAutoQuiz.js
+++ b/slackAutoQuiz.js
@@ -4,7 +4,7 @@ import { startQuizFlow } from "./quizFlow.js"; // ajustează calea corect
 export default function initSlackAutoQuiz(app, quizSessionMap) {
   const AUTO_CHANNEL_ID = process.env.SLACK_CHANNEL_ID;
 
-  const quizTypes = ["historical", "icebreaker", "movie_quote"];
+  const quizTypes = ["historical", "icebreaker", "movie_quote", "computer_trivia"];
 
   function getRandomType() {
     return quizTypes[Math.floor(Math.random() * quizTypes.length)];


### PR DESCRIPTION
- Fixed some issues that were present:
    - Bot crashed when trying to update quiz message with the countdown in the case where the quiz was sent through DM to a user. The `channel` field of the `update()` method used to update the quiz message was using the user's ID, but [I discovered that the DM channel ID needs to be used instead](https://github.com/slackapi/bolt-python/issues/626#issuecomment-1078588176).
    - The quiz checked for past 2 hours inactivity every 15 seconds. Now updated to check for every 2 hours.

- Updated the UI (quiz type selection UI) and the logic to support the new "Computer Trivia" type.